### PR TITLE
feat: Desativar Spring Security para fins de teste da API

### DIFF
--- a/src/main/java/com/ads/gynvagas/jobboard/JobBoardApplication.java
+++ b/src/main/java/com/ads/gynvagas/jobboard/JobBoardApplication.java
@@ -2,8 +2,9 @@ package com.ads.gynvagas.jobboard;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 
-@SpringBootApplication
+@SpringBootApplication(exclude = {SecurityAutoConfiguration.class})
 public class JobBoardApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/config/SecurityConfig.java
+++ b/src/main/java/config/SecurityConfig.java
@@ -1,0 +1,41 @@
+package config;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    private static final Logger logger = LoggerFactory.getLogger(SecurityConfig.class);
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        logger.info("Configuring Security Filter Chain");
+
+        http
+                .authorizeRequests(authorizeRequests -> {
+                    logger.info("Permitting all requests");
+                    authorizeRequests.anyRequest().permitAll();
+                })
+                .csrf(csrf -> {
+                    logger.info("Disabling CSRF");
+                    csrf.disable();
+                })
+                .formLogin(formLogin -> {
+                    logger.info("Disabling form login");
+                    formLogin.disable();
+                })
+                .httpBasic(httpBasic -> {
+                    logger.info("Disabling HTTP Basic authentication");
+                    httpBasic.disable();
+                });
+
+        return http.build();
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,3 +3,4 @@ spring.data.mongodb.host=localhost
 spring.data.mongodb.port=27017
 spring.data.mongodb.database=gynvagas
 #spring.profiles.active=no-security
+logging.level.org.springframework.security=DEBUG


### PR DESCRIPTION
- Atualizada a configuração de segurança para permitir todas as requisições e desativar a proteção CSRF.
- Removido o redirecionamento para a página de login padrão do Spring Security.
- Garantido que os endpoints da API estejam acessíveis sem autenticação para desenvolvimento e testes